### PR TITLE
feat: created `BasicStatsAggregator` cron

### DIFF
--- a/packages/be/config.js
+++ b/packages/be/config.js
@@ -26,6 +26,7 @@ module.exports = {
   // ===================================================================== Paths
   packageRoot: __dirname,
   repoRoot: Path.resolve(__dirname, '../../'),
+  cacheRoot: Path.resolve(__dirname, 'cache'),
   staticRoot: Path.resolve(__dirname, 'static'),
   publicRoot: Path.resolve(__dirname, 'public'),
   tmpRoot: Path.resolve(__dirname, 'tmp'),

--- a/packages/be/crons/basic-stats-aggregator.js
+++ b/packages/be/crons/basic-stats-aggregator.js
@@ -1,0 +1,89 @@
+/*
+ *
+ * ⏱️️ [Cron | every 5 mins] BasicStatsAggregator
+ *
+ */
+
+// ///////////////////////////////////////////////////// Imports + general setup
+// -----------------------------------------------------------------------------
+const ModuleAlias = require('module-alias')
+const Path = require('path')
+const Axios = require('axios')
+const Fs = require('fs-extra')
+const Express = require('express')
+require('dotenv').config({ path: Path.resolve(__dirname, '../.env') })
+
+const MC = require('../config')
+
+// ////////////////////////////////////////////////////////////////// Initialize
+MC.app = Express()
+
+// ///////////////////////////////////////////////////////////////////// Aliases
+ModuleAlias.addAliases({
+  '@Root': MC.packageRoot,
+  '@Modules': `${MC.packageRoot}/modules`
+})
+
+try {
+  const modulesRoot = `${MC.packageRoot}/modules`
+  const items = Fs.readdirSync(modulesRoot)
+  items.forEach((name) => {
+    const path = `${modulesRoot}/${name}`
+    if (Fs.statSync(path).isDirectory()) {
+      const moduleName = `${name[0].toUpperCase() + name.substring(1)}`
+      ModuleAlias.addAlias(`@Module_${moduleName}`, path)
+    }
+  })
+} catch (e) {
+  console.log(e)
+}
+
+// ///////////////////////////////////////////////////////////////////// Modules
+require('@Module_Database')
+require('@Module_Dataset')
+
+// /////////////////////////////////////////////////////////////////// Functions
+// -----------------------------------------------------------------------------
+// ///////////////////////////////////////////////////////////// getDatasetCount
+const getDatasetCount = async () => {
+  try {
+    return await MC.model.Dataset.countDocuments()
+  } catch (e) {
+    console.log('================================= [Function: getDatasetCount]')
+    throw e
+  }
+}
+
+// ///////////////////////////////////////////////////////////////// writeToDisc
+const writeToDisc = async (data) => {
+  try {
+    return new Promise((resolve) => {
+      Fs.writeFileSync(`${MC.cacheRoot}/basic-stats.json`, JSON.stringify(data))
+      resolve()
+    })
+  } catch (e) {
+    console.log('===================================== [Function: writeToDisc]')
+    throw e
+  }
+}
+
+// //////////////////////////////////////////////////////// BasicStatsAggregator
+const BasicStatsAggregator = async () => {
+  console.log('🤖 Basic stats aggregation started')
+  try {
+    const count = await getDatasetCount()
+    await writeToDisc({
+      count__datasets__total: count
+    })
+    console.log('🏁 Basic stats aggregation complete')
+    process.exit(0)
+  } catch (e) {
+    console.log('============================ [Function: BasicStatsAggregator]')
+    console.log(e)
+    process.exit(0)
+  }
+}
+
+// ////////////////////////////////////////////////////////////////// Initialize
+// -----------------------------------------------------------------------------
+MC.app.on('mongoose-connected', BasicStatsAggregator)

--- a/packages/fe/store/general.js
+++ b/packages/fe/store/general.js
@@ -55,6 +55,22 @@ const actions = {
       return false
     }
   },
+  // ///////////////////////////////////////////////////////////// getCachedFile
+  async getCachedFile ({ commit, dispatch }, path) {
+    try {
+      const response = await this.$axiosAuth.get('/get-cached-file', {
+        params: { path }
+      })
+      const file = response.data.payload
+      dispatch('setStaticFile', { path, file })
+      return file
+    } catch (e) {
+      console.log('===================== [Store Action: general/getCachedFile]')
+      console.log(e)
+      dispatch('setStaticFile', { path, file: false })
+      return false
+    }
+  },
   // ///////////////////////////////////////////////////////////// setStaticFile
   setStaticFile ({ commit, getters }, payload) {
     const staticFiles = CloneDeep(getters.staticFiles)


### PR DESCRIPTION
## Description
- A new cron has been created that will generate basic stats
- Currently it only generates the `count__datasets__total` stat
- `basic-stats.json` file is stored inside the `cache` directory and can be fetched on the frontend using the `getCachedFile` store action (newly added to `general` store) and subsequently accessed app-wide via the `general/staticFiles` getter.

## Ticket link
https://www.notion.so/agencyundone/endpoint-for-get-basic-stats-for-nav-be-03c4660442694885ab2aed0f4776959a