### PR TITLE
feat: implemented `Cacher` cron

### DIFF
--- a/packages/be/modules/dataset/logic/get-filters.js
+++ b/packages/be/modules/dataset/logic/get-filters.js
@@ -1,8 +1,6 @@
-console.log('💡 [endpoint] /get-filters')
-
 // ///////////////////////////////////////////////////////////////////// Imports
 // -----------------------------------------------------------------------------
-const { SendData, GetFileFromDisk } = require('@Module_Utilities')
+const { GetFileFromDisk } = require('@Module_Utilities')
 
 const MC = require('@Root/config')
 
@@ -44,23 +42,22 @@ const processFileExtensions = async (datasets) => {
 
 // //////////////////////////////////////////////////////////////////// Endpoint
 // -----------------------------------------------------------------------------
-MC.app.get('/get-filters', async (req, res) => {
+module.exports = async () => {
   try {
     const staticFilters = await GetFileFromDisk(`${MC.staticRoot}/filters.json`, true)
     const datasets = await MC.model.Dataset
       .find({})
       .select('categories file_extensions license location')
-    SendData(res, 200, 'Static file retrieved succesfully', {
+    return {
       sort: staticFilters.sort,
       limit: staticFilters.limit,
       filters: Object.assign({
         categories: await processCategories(datasets),
         fileTypes: await processFileExtensions(datasets)
       }, staticFilters.filters)
-    })
+    }
   } catch (e) {
-    console.log('==================================== [Endpoint: /get-filters]')
+    console.log('========================================= [Logic: GetFilters]')
     console.log(e)
-    SendData(res, 500, 'Something went wrong. Please try again.')
   }
-})
+}

--- a/packages/be/modules/utilities/rest/get-cached-file.js
+++ b/packages/be/modules/utilities/rest/get-cached-file.js
@@ -1,0 +1,23 @@
+console.log('💡 [endpoint] /get-cached-file')
+
+// ///////////////////////////////////////////////////////////////////// Imports
+// -----------------------------------------------------------------------------
+const { SendData, GetFileFromDisk } = require('@Module_Utilities')
+
+const MC = require('@Root/config')
+
+// //////////////////////////////////////////////////////////////////// Endpoint
+// -----------------------------------------------------------------------------
+MC.app.get('/get-cached-file', async (req, res) => {
+  try {
+    const file = await GetFileFromDisk(`${MC.cacheRoot}/${req.query.path}`, true)
+    if (!file) {
+      return SendData(res, 404, 'Can\'t find what you\'re looking for.')
+    }
+    SendData(res, 200, 'Static file retrieved succesfully', file)
+  } catch (e) {
+    console.log('================================ [Endpoint: /get-cached-file]')
+    console.log(e)
+    SendData(res, 404, 'Can\'t find what you\'re looking for.')
+  }
+})

--- a/packages/fe/content/pages/general.json
+++ b/packages/fe/content/pages/general.json
@@ -98,8 +98,7 @@
     "keys": {
       "categories": "Categories",
       "licenses": "Licenses",
-      "fileType": "File Type",
-      "location": "Location"
+      "fileTypes": "File Type"
     }
   }
 }

--- a/packages/fe/store/datasets.js
+++ b/packages/fe/store/datasets.js
@@ -88,12 +88,14 @@ const actions = {
     }
   },
   // //////////////////////////////////////////////////////////////// getFilters
-  async getFilters ({ commit, getters, dispatch }) {
+  async getFilters ({ commit }) {
     try {
-      const response = await this.$axiosAuth.get('/get-filters')
-      commit('SET_SORT_OPTIONS', response.data.payload.sort)
-      commit('SET_LIMIT_OPTIONS', response.data.payload.limit)
-      commit('SET_FILTERS', response.data.payload.filters)
+      const filters = await this.dispatch('general/getCachedFile', 'filters.json')
+      if (filters) {
+        commit('SET_SORT_OPTIONS', filters.sort)
+        commit('SET_LIMIT_OPTIONS', filters.limit)
+        commit('SET_FILTERS', filters.filters)
+      }
     } catch (e) {
       console.log('======================= [Store Action: datasets/getFilters]')
       console.log(e)


### PR DESCRIPTION
## Description
- `basic-stats.json` and `filters.json` are now generated by a new cron meant for caching data
- `/get-filters` endpoint has been converted (and deleted) to `get-filters.js` logic file. This logic is used by the Cacher cron to generate filters
- Fixed a small bug with some filters not appearing on frontend correctly and also removed some legacy filters