### PR TITLE
feat: cache typeahead data

### DIFF
--- a/packages/be/crons/cacher.js
+++ b/packages/be/crons/cacher.js
@@ -48,12 +48,24 @@ const GetFilters = require('@Module_Dataset/logic/get-filters')
 
 // /////////////////////////////////////////////////////////////////// Functions
 // -----------------------------------------------------------------------------
-// ///////////////////////////////////////////////////////////// getDatasetCount
-const getDatasetCount = async () => {
+// /////////////////////////////////////////////////////////////// getBasicStats
+const getBasicStats = async () => {
   try {
-    return await MC.model.Dataset.countDocuments()
+    return {
+      count__datasets__total: await MC.model.Dataset.countDocuments()
+    }
   } catch (e) {
-    console.log('================================= [Function: getDatasetCount]')
+    console.log('=================================== [Function: getBasicStats]')
+    throw e
+  }
+}
+
+// /////////////////////////////////////////////// getTypeaheadDatasetSearchData
+const getTypeaheadDatasetSearchData = async () => {
+  try {
+    return await MC.model.Dataset.find({}).select('-_id name slug')
+  } catch (e) {
+    console.log('=================== [Function: getTypeaheadDatasetSearchData]')
     throw e
   }
 }
@@ -78,18 +90,10 @@ const Cacher = async () => {
   console.log('🤖 Caching started')
   try {
     const start = process.hrtime()[0]
-    const count = await getDatasetCount()
     await writeToDisc([
-      {
-        filename: 'basic-stats.json',
-        data: {
-          count__datasets__total: count
-        }
-      },
-      {
-        filename: 'filters.json',
-        data: await GetFilters()
-      }
+      { filename: 'basic-stats.json', data: await getBasicStats() },
+      { filename: 'filters.json', data: await GetFilters() },
+      { filename: 'typeahead-dataset-search-data.json', data: await getTypeaheadDatasetSearchData() }
     ])
     const end = process.hrtime()[0]
     console.log(`🏁 Caching complete | took ${SecondsToHms(end - start)}`)

--- a/packages/be/modules/dataset/rest/get-dataset-list.js
+++ b/packages/be/modules/dataset/rest/get-dataset-list.js
@@ -49,7 +49,6 @@ const findDatasets = async (search = '', page = 1, limit = 10, sort = {}) => {
 MC.app.get('/get-dataset-list', async (req, res) => {
   try {
     const query = req.query
-    console.log(query)
     const search = await ParseQuerySearch(query.search)
     const page = await parseNumber(query.page)
     const limit = await parseNumber(query.limit)

--- a/packages/fe/components/form/fields/typeahead.vue
+++ b/packages/fe/components/form/fields/typeahead.vue
@@ -141,6 +141,9 @@ export default {
     },
     optionDisplayKey () {
       return this.scaffold.optionDisplayKey
+    },
+    optionReturnKey () {
+      return this.scaffold.optionReturnKey
     }
   },
 
@@ -170,7 +173,7 @@ export default {
     },
     optionSelected (index) {
       this.selectedOption = index
-      this.$emit('updateValue', this.options[index][this.optionDisplayKey])
+      this.$emit('updateValue', this.options[index][this.optionReturnKey])
     },
     optionIncludedInSearch (option) {
       const value = option[this.optionDisplayKey]


### PR DESCRIPTION
## Description
- Typeahead data caching has been added to `Cacher` cron and is cached with the following structure:
```json
[
  {
    "name": "Foo",
    "slug": "bar"
  },
  ...
]
```

- Typeahead field now supports returning a value that is different from the one displayed in the dropdown using the new `optionReturnKey` scaffold key. It can be used like so:
```js
{
  "name": "Foo", // ← "optionDisplayKey": "name"
  "slug": "bar" // ← "optionReturnKey": "slug"
}
```

## Ticket link
https://www.notion.so/agencyundone/Cache-typeahead-search-data-be-e8de64b336b445828bfe87e05c842df4