### PR TITLE
fix: Clicking on SP should not affect SPs on another CID

### DIFF
--- a/packages/fe/components/cid-card.vue
+++ b/packages/fe/components/cid-card.vue
@@ -114,6 +114,7 @@
 
           <CIDSlider
             v-if="storageProviders.length && !mobile"
+            :slider-id="hash"
             :storage-providers="storageProviders"
             @slide-changed="changeBottomPanelHeight" />
 

--- a/packages/fe/components/cid-slider.vue
+++ b/packages/fe/components/cid-slider.vue
@@ -1,6 +1,6 @@
 <template>
   <TabbedSlider
-    slider-id="cid-card-slider"
+    :slider-id="sliderId"
     @slide-changed="handleSlideChange">
 
     <template #before-tabs>
@@ -98,6 +98,11 @@ export default {
       type: Array,
       required: true,
       default: () => []
+    },
+    sliderId: {
+      type: String,
+      required: true,
+      default: ''
     }
   },
 

--- a/packages/fe/store/dataset.js
+++ b/packages/fe/store/dataset.js
@@ -65,6 +65,11 @@ const getMockCids = () => {
   for (let i = 0; i < 6; i++) {
     const cid = CloneDeep(mockCid)
     cid.title = `Genome in a Bottle 00${i}`
+    cid.hash = Math.floor(Math.random() * 9999998873867900).toString()
+    for (let j = 0; j < 4; j++) {
+      cid.storage_providers[j].id = Math.floor(Math.random() * 9000).toString()
+      cid.storage_providers[j].dealId = Math.floor(Math.random() * 10000).toString()
+    }
     mockCids.push(cid)
   }
   return {


### PR DESCRIPTION
## Description

Clicking on SP should not affect SPs on block. Fix is to make the block unique


## Screenshots 
<!-- Add screenshots or videos here, if none are available, delete this heading -->


## Ticket link
https://www.notion.so/agencyundone/Scroll-in-slider-on-dataset-singular-page-e7695b68ad384130895e16fe47d03745?pvs=4