### PR TITLE
fix: cid import bulk write

### DIFF
--- a/packages/be/crons/cid-importer.js
+++ b/packages/be/crons/cid-importer.js
@@ -286,7 +286,7 @@ const CidImporter = async () => {
      * args:
      *  limit number of entries to the database (this will only be used for test)
      */
-    await getCidFilesFromManifestList(limit * maxPages)
+    await getCidFilesFromManifestList(limit)
     const end = process.hrtime()[0]
     console.log(`📒 CID import finished | took ${SecondsToHms(end - start)}`)
     process.exit(0)


### PR DESCRIPTION
## Description
The import maximum for the bulk write operation was still using the value of maxpages x pagesize (= infinity) for when to write cids to the database in batches. This PR change the limit to be just the pagesize value for the limit, i.e. the bulkwrite will be triggered every 1000 unpacked cids.

Arguments can be added to the CLI command to override default values for max pages and page size, which are `Infinity` and `1000` respectively. See below:

`node cid-importer.js --maxpages 200 --pagesize 20`
