### PR TITLE
fix: seo meta fixes

### DIFF
--- a/packages/fe/content/markdown/privacy.md
+++ b/packages/fe/content/markdown/privacy.md
@@ -1,6 +1,6 @@
 ---
 heading: 'Privacy'
-description: 'This Privacy Policy governs all use of the datasets.filecoin.io website (the “Website”) and all content, software and products available at or through the Website, including the Dataset Explorer allowing discovery and exploration of open-access datasets stored on the Filecoin network (collectively, the “Services”).'
+description: 'This Privacy Policy governs all use of the openpanda.io website and all content, software and products available at or through the Website.'
 image: '/images/privacy/porous-cube-and-cutout-mobile.png'
 ---
 

--- a/packages/fe/content/markdown/terms.md
+++ b/packages/fe/content/markdown/terms.md
@@ -1,6 +1,6 @@
 ---
 heading: 'Terms of Use'
-description: 'The following terms and conditions govern all use of the openpanda.io website (the “Website”) and all content, software and products available at or through the Website, including the Open Panda platform allowing discovery and exploration of open-access datasets stored on the Filecoin network (collectively, the “Services”).<br><br>Please read these terms carefully. If you don’t agree to all of these terms and conditions (“Terms” or “TOS”), you are prohibited from using or accessing this Website or using the Services.<br><br>Protocol Labs, Inc. (“we,” “us”) may make changes to these Terms from time to time. Your continued use of or access to the Website or the Services following the posting of any changes to the Terms constitutes acceptance of those changes. If you don’t agree to these revisions, you should stop using the Website and Services.'
+description: 'The following terms and conditions govern all use of the openpanda.io website, including the Open Panda platform, allowing discovery and exploration of open-access datasets stored on the Filecoin network.'
 image: '/images/privacy/porous-cube-and-cutout-mobile.png'
 ---
 

--- a/packages/fe/content/pages/alpha.json
+++ b/packages/fe/content/pages/alpha.json
@@ -1,7 +1,7 @@
 {
   "seo": {
-    "title": "How to download - Open Panda",
-    "description": "Learn how to download files from a decentralized storage network using Open Panda. We're currently in a state of rapid iteration to further improve the download experience."
+    "title": "Alpha Release - Open Panda",
+    "description": "Open Panda is currently in an alpha release state, its services are available, but also being rapidly iterated upon."
   },
   "og": {
     "site_name": "Open Panda",


### PR DESCRIPTION
### Description

Fixes two incorrect areas of SEO meta

- [x] Descriptions on legal pages (terms and privacy) referred to the old project name and were too long
- [x] Wrong metadata on new `/alpha` page


