### PR TITLE
feat: failed cid retrieval scraper

### DIFF
--- a/packages/be/crons/cid-importer.js
+++ b/packages/be/crons/cid-importer.js
@@ -84,7 +84,9 @@ const retrieveCidFile = async (line, retryNo = 0) => {
       console.log(`Error retrieving CID ${JSON.parse(line).cid}. Retrying retrieval...`)
       await retrieveCidFile(line, retryNo + 1)
     } else {
-      console.log(`Could not retrieve CID ${JSON.parse(line).cid}. Max retries reached.`)
+      const cid = JSON.parse(line).cid
+      console.log(`Could not retrieve CID ${cid}. Max retries reached.`)
+      await cacheFailedCID(cid)
     }
   }
 }
@@ -151,6 +153,16 @@ const writeFileMetadataToDatabase = async (retrievedFiles) => {
     return response.result
   } catch (e) {
     console.log('========================= [Function: writeCidFilesToDatabase]')
+    console.log(e)
+  }
+}
+
+// -------------------------------------------------------------- cacheFailedCid
+const cacheFailedCID = async (cid) => {
+  try {
+    await Pipeline(`${cid}\n`, Fs.createWriteStream(`${CID_TMP_DIR}/failed-cid-retrievals.txt`, { flags: 'a' }))
+  } catch (e) {
+    console.log('================================= [Function: cacheFailedCID ]')
     console.log(e)
   }
 }

--- a/packages/be/scripts/failed-cid-import-scraper.js
+++ b/packages/be/scripts/failed-cid-import-scraper.js
@@ -1,0 +1,62 @@
+/**
+ *
+ * ⏱️️ [Script] Failed CID Import Scraper
+ *
+ * Temporary script to scrape pm2 logs from the CID Importer cron and find any failed CID retrievals
+ * These CIDs are saved to a txt file in the tmp folder called failed-cid-retrievals.txt
+ */
+
+// ///////////////////////////////////////////////////// Imports + general setup
+// -----------------------------------------------------------------------------
+const Path = require('path')
+const Fs = require('fs-extra')
+const Util = require('util')
+const Stream = require('stream')
+const Pipeline = Util.promisify(Stream.pipeline)
+const readline = require('node:readline')
+require('dotenv').config({ path: Path.resolve(__dirname, '../.env') })
+
+const MC = require('../config')
+
+const CID_TMP_DIR = Path.resolve(`${MC.packageRoot}/tmp/cid-files`)
+
+// /////////////////////////////////////////////////////////////////// Functions
+// --------------------------------------------- ParseLogsForFailedCidRetrievals
+const ParseLogsForFailedCidRetrievals = async () => {
+  try {
+    console.log('Starting search for failed CID retrievals.')
+    if (Fs.existsSync(`${CID_TMP_DIR}/cid-importer-pm2-logs.txt`)) {
+      const pm2log = Fs.createReadStream(`${CID_TMP_DIR}/cid-importer-pm2-logs.txt`)
+      const rl = readline.createInterface({
+        input: pm2log,
+        crlfDelay: Infinity
+      })
+      const failedCids = []
+      for await (const line of rl) {
+        if (line.includes('Max retries reached')) {
+          const terms = line.split(' ').filter(item => item.endsWith('.'))
+          const cid = terms[0].replace('.', '')
+          failedCids.push(cid)
+        }
+      }
+      console.log(failedCids)
+      const len = failedCids.length
+      for (let i = 0; i < len; i++) {
+        const newline = failedCids[i]
+        await Pipeline(`${newline}\n`, Fs.createWriteStream(`${CID_TMP_DIR}/failed-cid-retrievals.txt`, { flags: 'a' }))
+      }
+    } else {
+      console.log('Could not find file cid-importer-pm2-logs.txt.')
+    }
+    console.log('Finished parsing logs for failed CID retrievals. CIDs stored to the temp folder in failed-cid-retrievals.txt.')
+    process.exit(0)
+  } catch (e) {
+    console.log('================= [Function: ParseLogsForFailedCidRetrievals]')
+    console.log(e)
+    process.exit(0)
+  }
+}
+
+// ////////////////////////////////////////////////////////////////// Initialize
+// -----------------------------------------------------------------------------
+ParseLogsForFailedCidRetrievals ()


### PR DESCRIPTION
## Description
Added script to save CIDs from failed file retrievals to a file in the temp folder called `failed-cid-retrievals.txt`. This is temporary script that we'll likely only have to run once. It scrapes the pm2 log of the `op-S-cid-importer` process searching for CIDs where the max number of retrieval retries was reached.

Also updated is the cid-importer cron which will now save these failed CIDs to the `failed-cid-retrievals.txt` file directly as it runs.