### PR TITLE
feat: dynamic seo generation on dataset singular pages

### DIFF
--- a/packages/fe/pages/about.vue
+++ b/packages/fe/pages/about.vue
@@ -31,6 +31,10 @@ export default {
     await store.dispatch('general/getBaseData', { key: 'about', data: AboutPageData })
   },
 
+  head () {
+    return this.$compileSeo(this.$getSeo(this.tag))
+  },
+
   computed: {
     ...mapGetters({
       siteContent: 'general/siteContent'

--- a/packages/fe/pages/alpha.vue
+++ b/packages/fe/pages/alpha.vue
@@ -30,6 +30,10 @@ export default {
     await store.dispatch('general/getBaseData', { key: 'alpha', data: AlphaPageData })
   },
 
+  head () {
+    return this.$compileSeo(this.$getSeo(this.tag))
+  },
+
   computed: {
     ...mapGetters({
       siteContent: 'general/siteContent'

--- a/packages/fe/pages/dataset/_id.vue
+++ b/packages/fe/pages/dataset/_id.vue
@@ -249,9 +249,9 @@ export default {
     }
   },
 
-  // head () {
-  //   return this.$compileSeo(this.$getSeo(this.tag))
-  // },
+  head () {
+    return this.$compileSeo(this.$getSeo('singular'))
+  },
 
   computed: {
     ...mapGetters({
@@ -290,7 +290,6 @@ export default {
       return this.dataset.createdAt ? this.$moment(this.dataset.createdAt).format('YYYY') : '-'
     },
     datasetSize () {
-      console.log(this.dataset.data_size, this.dataset.data_size ? this.$formatBytes(this.dataset.data_size) : '-')
       return this.dataset.data_size ? this.$formatBytes(this.dataset.data_size) : '-'
     },
     totalDataOnNetwork () {

--- a/packages/fe/pages/dataset/_id.vue
+++ b/packages/fe/pages/dataset/_id.vue
@@ -250,16 +250,15 @@ export default {
   },
 
   head () {
-    const generalSeo = this.$getSeo()
     const dataset = this.dataset
-    const datasetSeo = {
+    const siteUrl = this.siteContent.general.og.url
+    return this.$compileSeo(this.$getSeo(this.id, null, {
       title: `${dataset.name} - Dataset on Open Panda`,
       description: dataset.description_short,
       og_site_name: `${dataset.name} - Dataset on Open Panda`,
-      og_url: `${generalSeo.og_url}/dataset/${dataset.slug}`,
+      og_url: `${siteUrl}/dataset/${dataset.slug}`,
       og_image: `/images/datasets/${dataset.slug}.jpg`
-    }
-    return this.$compileSeo(Object.assign(generalSeo, datasetSeo))
+    }))
   },
 
   computed: {

--- a/packages/fe/pages/dataset/_id.vue
+++ b/packages/fe/pages/dataset/_id.vue
@@ -250,7 +250,16 @@ export default {
   },
 
   head () {
-    return this.$compileSeo(this.$getSeo('singular'))
+    const generalSeo = this.$getSeo()
+    const dataset = this.dataset
+    const datasetSeo = {
+      title: `${dataset.name} - Dataset on Open Panda`,
+      description: dataset.description_short,
+      og_site_name: `${dataset.name} - Dataset on Open Panda`,
+      og_url: `${generalSeo.og_url}/dataset/${dataset.slug}`,
+      og_image: `/images/datasets/${dataset.slug}.jpg`
+    }
+    return this.$compileSeo(Object.assign(generalSeo, datasetSeo))
   },
 
   computed: {

--- a/packages/fe/pages/how-to-download.vue
+++ b/packages/fe/pages/how-to-download.vue
@@ -30,6 +30,10 @@ export default {
     await store.dispatch('general/getBaseData', { key: 'how-to-download', data: HowToDownloadPageData })
   },
 
+  head () {
+    return this.$compileSeo(this.$getSeo(this.tag))
+  },
+
   computed: {
     ...mapGetters({
       siteContent: 'general/siteContent'

--- a/packages/fe/plugins/seo.js
+++ b/packages/fe/plugins/seo.js
@@ -4,14 +4,14 @@
 // -----------------------------------------------------------------------------
 // ///////////////////////////////////////////////// Get SEO and Open Graph data
 // ----------------------------- Return global SEO if no identifier is specified
-const GetSeo = store => (identifier = 'general', key) => {
+const GetSeo = store => (identifier = 'general', key, override) => {
   const siteContent = store.getters['general/siteContent']
   const language = store.getters['general/language']
   let data = siteContent[identifier]
   if (!data) { data = siteContent.general }
   const seo = data.seo
   const og = data.og
-  return {
+  const metadata = {
     language,
     title: seo.title,
     description: seo.description,
@@ -22,6 +22,7 @@ const GetSeo = store => (identifier = 'general', key) => {
     og_image: og.image,
     key
   }
+  return Object.assign(metadata, override)
 }
 
 // ///////////////////////////////////////////////// Convert SEO to final output

--- a/packages/fe/plugins/seo.js
+++ b/packages/fe/plugins/seo.js
@@ -7,6 +7,23 @@
 const GetSeo = store => (identifier = 'general', key) => {
   const siteContent = store.getters['general/siteContent']
   const language = store.getters['general/language']
+  if (identifier === 'singular') {
+    const general = siteContent.general
+    const dataset = store.getters['dataset/dataset']
+    const seo = general.seo
+    const og = general.og
+    return {
+      language,
+      title: `${dataset.name} - Dataset on Open Panda`,
+      description: dataset.description_short,
+      structured_data: seo.structured_data,
+      og_site_name: `${dataset.name} - Dataset on Open Panda`,
+      og_url: `${og.url}/dataset/${dataset.slug}`,
+      og_type: og.type,
+      og_image: `/images/datasets/${dataset.slug}.jpg`,
+      key
+    }
+  }
   let data = siteContent[identifier]
   if (!data) { data = siteContent.general }
   const seo = data.seo

--- a/packages/fe/plugins/seo.js
+++ b/packages/fe/plugins/seo.js
@@ -7,23 +7,6 @@
 const GetSeo = store => (identifier = 'general', key) => {
   const siteContent = store.getters['general/siteContent']
   const language = store.getters['general/language']
-  if (identifier === 'singular') {
-    const general = siteContent.general
-    const dataset = store.getters['dataset/dataset']
-    const seo = general.seo
-    const og = general.og
-    return {
-      language,
-      title: `${dataset.name} - Dataset on Open Panda`,
-      description: dataset.description_short,
-      structured_data: seo.structured_data,
-      og_site_name: `${dataset.name} - Dataset on Open Panda`,
-      og_url: `${og.url}/dataset/${dataset.slug}`,
-      og_type: og.type,
-      og_image: `/images/datasets/${dataset.slug}.jpg`,
-      key
-    }
-  }
   let data = siteContent[identifier]
   if (!data) { data = siteContent.general }
   const seo = data.seo


### PR DESCRIPTION
## Description
Dynamic seo generation on dataset singular pages. Logic has been added to the `$getSeo` directive in `plugins/seo.js` to account for singular pages and retrieve pertinent data from the dataset store.


## Ticket link
https://www.notion.so/agencyundone/Dynamically-generate-SEO-metadata-for-singular-datasets-3481a284e3784e1ca4843f32a8865284?pvs=4