### PR TITLE
chore: use new google tag manager instance id

### DIFF
--- a/packages/fe/nuxt.config.js
+++ b/packages/fe/nuxt.config.js
@@ -135,7 +135,7 @@ export default {
   // ------------------------- Doc: https://github.com/nuxt-community/gtm-module
   gtm: {
     // Currently hardcoded, can be added as an environment variable instead
-    id: 'GTM-NH8TLHW',
+    id: 'GTM-WSHTSSQ',
     pageTracking: true
   },
   // ////////////////////////////////////////////////////// [Module] GoogleFonts


### PR DESCRIPTION
Updates Google Tag Manager to use a new ID, which includes all analytics tags and triggers that were previously configured.